### PR TITLE
Implement Backend API

### DIFF
--- a/functions/format-docs.js
+++ b/functions/format-docs.js
@@ -2,7 +2,6 @@
   *
   * Takes the returned docs and reformats it w/ the info we need.
   * the map() array func will return a list after iterating over every doc obj
-  * skipping on the short name.
   * 
   */
  function main(params) {
@@ -14,6 +13,7 @@
 	            id: doc.id,
 	            //items for dealerships:
 	            full_name: doc.full_name,
+				short_name: doc.short_name,
 	            city: doc.city,
 	            state: doc.state,
 	            st: doc.st,
@@ -38,6 +38,7 @@
     	    entries: params.rows.map( (row) => { return { //yet another obj
     	        id: row.doc.id,
     	        full_name: row.doc.full_name,
+				short_name: row.doc.short_name,
     	        city: row.doc.city,
     	        state: row.doc.state,
     	        st: row.doc.st,

--- a/functions/pass-the-docs.js
+++ b/functions/pass-the-docs.js
@@ -25,7 +25,7 @@
 	    return {
 	        query: {
 	            "selector": {
-	                "dealership": params.dealerId
+	                "dealership": parseInt(params.dealerId) //is auto-converted to string when passed back
 	            },
 	            "fields": [
 	                "id", "name", "review",

--- a/server/djangoapp/models.py
+++ b/server/djangoapp/models.py
@@ -9,7 +9,7 @@ class CarMake(models.Model):
     name = models.CharField(max_length=25, null=False, default='Car Make')
     description = models.CharField(max_length=500, default="Description of car make or manufacturer.")
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "Make: " + self.name + " - " + self.description
 
 
@@ -58,7 +58,29 @@ class CarModel(models.Model):
         return self.name + " " + self.car_year + " - " + self.car_type
 
 
-# <HINT> Create a plain Python class `CarDealer` to hold dealer data
+
+class CarDealer:
+    """
+    Proxy that holds onto Dealer data returned from the get-all-dealers service
+    Thus it's not a subclass of the Django Model... (just a container)
+    """
+    def __init__(self, address, city, full_name, db_id, lat, long, short_name, st, db_zip):
+        # I'm not likely to bother with the existing ID or ZIP classes/methods but I've appended db_ to be safe
+        self.address = address
+        self.city = city
+        self.full_name = full_name
+        self.id = db_id
+        self.lat = lat
+        self.long = long
+        self.short_name = short_name
+        self.st = st
+        self.zip = db_zip
+
+
+    def __str__(self) -> str: 
+        #TIL -> str is a func annotation. gonna leave it since vscode keeps adding it.
+        return "Dealer name: " + self.full_name
+
 
 
 # <HINT> Create a plain Python class `DealerReview` to hold review data

--- a/server/djangoapp/models.py
+++ b/server/djangoapp/models.py
@@ -63,18 +63,22 @@ class CarDealer:
     """
     Proxy that holds onto Dealer data returned from the get-all-dealers service
     Thus it's not a subclass of the Django Model... (just a container)
+    Has a flexible constructor to account for possibly missing information.
+        (And there seems to be one dealer in there like that...)
     """
-    def __init__(self, address, city, full_name, db_id, lat, long, short_name, st, db_zip):
-        # I'm not likely to bother with the existing ID or ZIP classes/methods but I've appended db_ to be safe
-        self.address = address
-        self.city = city
-        self.full_name = full_name
-        self.id = db_id
-        self.lat = lat
-        self.long = long
-        self.short_name = short_name
-        self.st = st
-        self.zip = db_zip
+    def __init__(self, kwargs):
+        """
+        kwargs should just be a dictionary
+        """
+        self.address = kwargs.get("address",'No Address Listed')
+        self.city = kwargs.get("city", "Unknown City")
+        self.full_name = kwargs.get("full_name", "Unnamed Dealership")
+        self.id = kwargs.get("id", None)
+        self.lat = kwargs.get('lat', None)
+        self.long = kwargs.get('long', None)
+        self.short_name = kwargs.get('short_name', 'Unnamed')
+        self.st = kwargs.get('st', "NA")
+        self.zip = kwargs.get('zip', 00000)
 
 
     def __str__(self) -> str: 
@@ -86,18 +90,25 @@ class DealerReview:
     """
     Proxy that holds onto Review data returned from the get-dealer-reivew service
     Thus it's not a subclass of the Django Model... (just a container)
+    Has a flexible constructor to account for reviews missing information. 
+        (e.g. an exsiting one for #13 with no purchase info)
     """
-    def __init__(self, dealership, name, purchase, review, purchase_date, car_make, car_model, car_year, sentiment, r_id) -> None:
-        self.dealership = dealership
-        self.name = name
-        self.purchase = purchase
-        self.review = review
-        self.purchase_date = purchase_date
-        self.car_make = car_make
-        self.car_model = car_model
-        self.car_year = car_year
-        self.sentiment = sentiment
-        self.id = r_id
+    def __init__(self, kwargs) -> None:
+        """
+        "kwargs" should just be a dictionary with all the data you need.
+        """
+        print('Constructing review object with the following:\n kwargs: {}'.format(kwargs))
+        self.dealership = kwargs.get('dealership',1)
+        self.name = kwargs.get('name', 'Anonymous Reviewer')
+        self.purchase = kwargs.get('purchase', False)
+        self.review = kwargs.get('review', 'No review.')
+        self.purchase_date = kwargs.get('purchase_date', None)
+        self.car_make = kwargs.get('car_make', None)
+        self.car_model = kwargs.get('car_model', None)
+        self.car_year = kwargs.get('car_year', None)
+        self.id = kwargs.get('id', 123) # shouldn't be 0/none...
+        self.sentiment = kwargs.get('sentiment', 'neutral') # uses a separate feature from func call to generate
+        print('constructed review with id {}. Author name: {}'.format(self.id, self.name))
 
     def __str__(self) -> str:
         return self.dealership + ": " + self.name + " - " + self.review

--- a/server/djangoapp/models.py
+++ b/server/djangoapp/models.py
@@ -82,5 +82,22 @@ class CarDealer:
         return "Dealer name: " + self.full_name
 
 
+class DealerReview:
+    """
+    Proxy that holds onto Review data returned from the get-dealer-reivew service
+    Thus it's not a subclass of the Django Model... (just a container)
+    """
+    def __init__(self, dealership, name, purchase, review, purchase_date, car_make, car_model, car_year, sentiment, r_id) -> None:
+        self.dealership = dealership
+        self.name = name
+        self.purchase = purchase
+        self.review = review
+        self.purchase_date = purchase_date
+        self.car_make = car_make
+        self.car_model = car_model
+        self.car_year = car_year
+        self.sentiment = sentiment
+        self.id = r_id
 
-# <HINT> Create a plain Python class `DealerReview` to hold review data
+    def __str__(self) -> str:
+        return self.dealership + ": " + self.name + " - " + self.review

--- a/server/djangoapp/restapis.py
+++ b/server/djangoapp/restapis.py
@@ -49,14 +49,19 @@ def get_dealers_from_cf(url, **kwargs):
         # dealers = json_result['rows']
         dealers = json_result['entries'] # this is a list of dicts
 
-        for d in dealers:
-            # we are now accessing each individual dict
-            # Reincarnate the dict as a CarDealer obj
-            dealer_obj = CarDealer(address=d['address'], city=d["city"], full_name=d["full_name"],
-                db_id=d["id"], lat=d["lat"], long=d["long"], short_name=d["short_name"],
-                st=d["st"], db_zip=d["zip"])
-            # stick the obj into our results list
-            results.append(dealer_obj)
+        #test_access = dealers[0]['address']
+        #print(test_access) # success
+
+        for dealer in dealers:
+            i = 0
+            for key in dealer: #Get KeyError without this...
+                while i < 1: # prevent it from actually doing this for every key
+                    # reincarnate it as a CarDealer obj
+                    dealer_obj = CarDealer(address=dealer['address'], city=dealer["city"], full_name=dealer["full_name"],
+                        db_id=dealer["id"], lat=dealer["lat"], long=dealer["long"], short_name=dealer["short_name"],
+                        st=dealer["st"], db_zip=dealer["zip"])
+                    results.append(dealer_obj)
+                    i += 1 # i++ is not a thing in Python lol...
 
     return results
 

--- a/server/djangoapp/restapis.py
+++ b/server/djangoapp/restapis.py
@@ -109,7 +109,6 @@ def get_dealer_reviews_from_cf(url, **kwargs):
     For some reason, this requires authentication be sent with the request... but is a public api.
     """
     results =[]
-    API_KEY = ""
 
     # Check for "required" kwargs then make request
     if kwargs['dealerId']:

--- a/server/djangoapp/restapis.py
+++ b/server/djangoapp/restapis.py
@@ -1,13 +1,29 @@
 import requests
 import json
-# import related models here
+from .models import CarDealer
 from requests.auth import HTTPBasicAuth
 
 
 # Create a `get_request` to make HTTP GET requests
 # e.g., response = requests.get(url, params=params, headers={'Content-Type': 'application/json'},
 #                                     auth=HTTPBasicAuth('apikey', api_key))
-
+def get_request(url, **kwargs):
+    print(kwargs) # these are all the URL params to associate w/ call
+    print("GET from {} ".format(url))
+    try:
+        # ...calling the request lib's get method with URL + params and store it
+        response = requests.get(url, headers={'Content-type': 'application/json'},
+            params=kwargs)
+            # are we gonna need the auth info? we should, right?
+    except:
+        # ...if that fails leave a general note.
+        print("Network exception occurred")
+    # relay status code info to console
+    status_code = response.status_code
+    print("Response status {}".format(status_code))
+    # package and return json data
+    json_data = json.loads(response.text)
+    return json_data
 
 # Create a `post_request` to make HTTP POST requests
 # e.g., response = requests.post(url, params=kwargs, json=payload)
@@ -17,6 +33,32 @@ from requests.auth import HTTPBasicAuth
 # def get_dealers_from_cf(url, **kwargs):
 # - Call get_request() with specified arguments
 # - Parse JSON results into a CarDealer object list
+def get_dealers_from_cf(url, **kwargs):
+    """
+    This function:
+        1. Parses the json data returned from the request / "get-all-dealers" Cloud function
+        2. Puts it into a proxy CarDealers obj.
+        3. Creates and returns a list of those proxies.
+    
+    At this moment it takes kwargs (state filter), but doesn't do anything with it.
+    """
+    results = [] # we're gonna stuff each obj into a list
+    json_result = get_request(url)
+    if json_result:
+        # Get the row list from the obj and save it as our dealers
+        # dealers = json_result['rows']
+        dealers = json_result['entries'] # this is a list of dicts
+
+        for d in dealers:
+            # we are now accessing each individual dict
+            # Reincarnate the dict as a CarDealer obj
+            dealer_obj = CarDealer(address=d['address'], city=d["city"], full_name=d["full_name"],
+                db_id=d["id"], lat=d["lat"], long=d["long"], short_name=d["short_name"],
+                st=d["st"], db_zip=d["zip"])
+            # stick the obj into our results list
+            results.append(dealer_obj)
+
+    return results
 
 
 # Create a get_dealer_reviews_from_cf method to get reviews by dealer id from a cloud function

--- a/server/djangoapp/restapis.py
+++ b/server/djangoapp/restapis.py
@@ -1,20 +1,22 @@
+from os import name
 import requests
 import json
-from .models import CarDealer
+from .models import CarDealer, DealerReview
 from requests.auth import HTTPBasicAuth
 
 
-# Create a `get_request` to make HTTP GET requests
-# e.g., response = requests.get(url, params=params, headers={'Content-Type': 'application/json'},
-#                                     auth=HTTPBasicAuth('apikey', api_key))
 def get_request(url, **kwargs):
+    """
+    Utility function to make HTTP GET requests
+    Currently doesn't need/use authenticate kwarg in get method... auth=HTTPBasicAuth('apikey',api_key)
+    """
     print(kwargs) # these are all the URL params to associate w/ call
     print("GET from {} ".format(url))
     try:
         # ...calling the request lib's get method with URL + params and store it
         response = requests.get(url, headers={'Content-type': 'application/json'},
             params=kwargs)
-            # are we gonna need the auth info? we should, right?
+            # params = kwargs?
     except:
         # ...if that fails leave a general note.
         print("Network exception occurred")
@@ -29,18 +31,15 @@ def get_request(url, **kwargs):
 # e.g., response = requests.post(url, params=kwargs, json=payload)
 
 
-# Create a get_dealers_from_cf method to get dealers from a cloud function
-# def get_dealers_from_cf(url, **kwargs):
-# - Call get_request() with specified arguments
-# - Parse JSON results into a CarDealer object list
-def get_dealers_from_cf(url, **kwargs):
+# Not 100% sure if I'll repurpose this to include ability to filter by state
+# Or if I'll create a separate function for it...
+# separate sounds better for testing / compartmentalizing.
+def get_dealers_from_cf(url):
     """
-    This function:
+    This function calls get_request() w/ the specified args then:
         1. Parses the json data returned from the request / "get-all-dealers" Cloud function
         2. Puts it into a proxy CarDealers obj.
         3. Creates and returns a list of those proxies.
-    
-    At this moment it takes kwargs (state filter), but doesn't do anything with it.
     """
     results = [] # we're gonna stuff each obj into a list
     json_result = get_request(url)
@@ -70,7 +69,53 @@ def get_dealers_from_cf(url, **kwargs):
 # def get_dealer_by_id_from_cf(url, dealerId):
 # - Call get_request() with specified arguments
 # - Parse JSON results into a DealerView object list
+def get_dealer_reviews_from_cf(url, **kwargs):
+    """
+    This function calls get_request() w/ the specified args (dealerId) then:
+        1. Parses the json data returned from the request / "get-dealer-reviews" Cloud function
+        2. Puts it into a proxy DealerReviews obj.
+        3. Creates and returns a list of those proxies.
+    """
+    results =[]
 
+    # Check for "required" kwargs then make request
+    if kwargs['dealerId']:
+        json_result = get_request(url, dealerId=kwargs['dealerId'])
+    else:
+        print('Dealer ID not supplied in kwargs.')
+        results.append("Could not execute request: missing Dealer ID")
+    
+    # Continue with business
+    if json_result['entries']:
+        reviews = json_result['entries']
+        
+        # test access
+        test_access = reviews[0]['review']
+        print(test_access)
+
+        # I'm hoping this just works
+        for review in reviews:
+            review_obj = DealerReview(dealership=review['dealership'], name=review['name'], 
+                purchase=review['purchase'], review=review['review'], purchase_date=review['purchase_date'],
+                car_make=review['car_make'], car_model=review['car_model'], car_year=review['car_year'],
+                sentiment=review['sentiment'], r_id=review['id'])
+            results.append(review_obj)
+        """
+        for review in reviews:
+            i = 0
+            for key in review: # Still get KeyError without this.
+                #reincarnate as DealerReview obj
+                review_obj = DealerReview(dealership=review['dealership'], name=review['name'], 
+                    purchase=review['purchase'], review=review['review'], purchase_date=review['purchase_date'],
+                    car_make=review['car_make'], car_model=review['car_model'], car_year=review['car_year'],
+                    sentiment=review['sentiment'], r_id=review['id'])
+                results.append(review_obj)
+                i += 1
+        """
+    else:
+        print('No entries received for Dealer Id {}'.format(kwargs['dealerId']))
+        results = 'Could not receive review data.'
+    return results
 
 # Create an `analyze_review_sentiments` method to call Watson NLU and analyze text
 # def analyze_review_sentiments(text):

--- a/server/djangoapp/templates/djangoapp/dealer_details.html
+++ b/server/djangoapp/templates/djangoapp/dealer_details.html
@@ -1,18 +1,17 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <title>Dealership Review</title>
-    {% load static %}
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
-</head>
+{% extends "djangoapp/base.html" %}
+<!-- 
+    EXTENDS BASE TEMPLATE BLOCKS:
+    - title
+    - content
+-->
+{% load static %}
+    
+<!-- Update Title: I'd like to include dealer's name but we only have int..-->
+{% block title %}Reviews for Dealer{% endblock %}
 
-    <body>
-
-    <!--Add a nav bar here -->
-
+<!-- PAGE CONTENT -->
+{% block content %}
     <!-- Add reviews as cards -->
-
-    </body>
-
-</html>
+    <p>Dealer Reviews</p>
+    <p>{{reviews}}</p>
+{% endblock content %}

--- a/server/djangoapp/templates/djangoapp/dealer_details.html
+++ b/server/djangoapp/templates/djangoapp/dealer_details.html
@@ -13,5 +13,7 @@
 {% block content %}
     <!-- Add reviews as cards -->
     <p>Dealer Reviews</p>
-    <p>{{reviews}}</p>
+    {% for r in reviews %}
+        <p>{{r.id}}, {{r.name}}, {{r.review}}</p>
+    {% endfor %}
 {% endblock content %}

--- a/server/djangoapp/templates/djangoapp/index.html
+++ b/server/djangoapp/templates/djangoapp/index.html
@@ -19,4 +19,5 @@
 {% block content %}
     <!--Add a dealer table here -->
     <p>Dealer Table</p>
+    <p>{{dealers}}</p>
 {% endblock content %}

--- a/server/djangoapp/urls.py
+++ b/server/djangoapp/urls.py
@@ -21,6 +21,8 @@ urlpatterns = [
     path(route='logout/', view=views.logout_request, name="logout"),
 
     path(route='', view=views.get_dealerships, name='index'),
+    # e.g. ..djangoapp/dealer/CA
+    path(route='dealer/<str:state>/', view=views.get_state_dealers, name="state_dealers"), # mostly for testing
 
     # e.g. ..djangoapp/dealer/15
     path(route='dealer/<int:dealer_id>/', view=views.get_dealer_details, name='dealer_details'),

--- a/server/djangoapp/urls.py
+++ b/server/djangoapp/urls.py
@@ -22,7 +22,8 @@ urlpatterns = [
 
     path(route='', view=views.get_dealerships, name='index'),
 
-    # path for dealer reviews view
+    # e.g. ..djangoapp/dealer/15
+    path(route='dealer/<int:dealer_id>/', view=views.get_dealer_details, name='dealer_details'),
 
     # path for add a review view
 

--- a/server/djangoapp/urls.py
+++ b/server/djangoapp/urls.py
@@ -21,8 +21,8 @@ urlpatterns = [
     path(route='logout/', view=views.logout_request, name="logout"),
 
     path(route='', view=views.get_dealerships, name='index'),
-    # e.g. ..djangoapp/dealer/CA
-    path(route='dealer/<str:state>/', view=views.get_state_dealers, name="state_dealers"), # mostly for testing
+    # e.g. ..djangoapp/state/CA
+    path(route='state/<str:state>/', view=views.get_state_dealers, name="state_dealers"), # mostly for testing
 
     # e.g. ..djangoapp/dealer/15
     path(route='dealer/<int:dealer_id>/', view=views.get_dealer_details, name='dealer_details'),

--- a/server/djangoapp/views.py
+++ b/server/djangoapp/views.py
@@ -98,7 +98,7 @@ def registration_request(request):
 # #
 
 # API URLS - all GET requests return JSON with "entries" key containing list of reviews
-REVIEW_API_URL = "https://1984d932.us-south.apigw.appdomain.cloud/api/review " 
+REVIEW_API_URL = "https://1984d932.us-south.apigw.appdomain.cloud/api/review" 
     # GET: get-dealer-review (requires param dealerId)
     # POST: save-review
 DEALERSHIP_API_URL = "https://1984d932.us-south.apigw.appdomain.cloud/api/dealerships" 
@@ -141,7 +141,7 @@ def get_dealer_details(request, dealer_id):
 
         #review_IDs = ' '.join([str(review.id) for review in reviews])
         # Verify we do have Review objects
-        print(reviews) # print(reviews[0].review)
+        print(reviews[0].review) # print(reviews[0].review)
         context['reviews'] = reviews
         return render(request, 'djangoapp/dealer_details.html', context)
 

--- a/server/djangoapp/views.py
+++ b/server/djangoapp/views.py
@@ -3,7 +3,7 @@ from django.http import HttpResponseRedirect, HttpResponse
 from django.contrib.auth.models import User
 from django.shortcuts import get_object_or_404, render, redirect
 # from .models import related models
-# from .restapis import related methods
+from .restapis import get_dealers_from_cf
 from django.contrib.auth import login, logout, authenticate
 from django.contrib import messages
 from django.views.generic.base import TemplateView
@@ -93,10 +93,23 @@ def registration_request(request):
             context['message'] = "Sign up for a new account or login above."
             return render(request, 'djangoapp/registration.html', context)
 
-# Update the `get_dealerships` view to render the index page with a list of dealerships
+# #
+# IBM CLOUD FUNCTION API INTERACTIONS
+# #
+
 def get_dealerships(request):
     context = {}
     if request.method == "GET":
+        # My API is currently setup to allow the following link to run the "get-all-dealers" Function
+        url = "https://1984d932.us-south.apigw.appdomain.cloud/api/dealership"
+        dealerships = get_dealers_from_cf(url) # should be a list of CarDealer objs.
+        #dealer_names = ' '.join([dealer.short_name for dealer in dealerships]) # dot-access cuz it should be an object...
+        dealer_names = []
+        for dealer in dealerships:
+            print(dealer.short_name)
+            dealer_names.append(dealer.short_name)
+        #dealer_names = set(pull_dealer_names)
+        context['dealers'] = dealer_names
         return render(request, 'djangoapp/index.html', context)
 
 

--- a/server/djangoapp/views.py
+++ b/server/djangoapp/views.py
@@ -3,7 +3,7 @@ from django.http import HttpResponseRedirect, HttpResponse
 from django.contrib.auth.models import User
 from django.shortcuts import get_object_or_404, render, redirect
 # from .models import related models
-from .restapis import get_dealer_reviews_from_cf, get_dealers_from_cf
+from .restapis import get_dealer_by_state_from_cf, get_dealer_reviews_from_cf, get_dealers_from_cf
 from django.contrib.auth import login, logout, authenticate
 from django.contrib import messages
 from django.views.generic.base import TemplateView
@@ -13,15 +13,6 @@ import json
 
 # Get an instance of a logger
 logger = logging.getLogger(__name__)
-
-# API URLS - all GET requests return JSON with "entries" key containing list of reviews
-REVIEW_API_URL = "https://1984d932.us-south.apigw.appdomain.cloud/api/review " 
-    # GET: get-dealer-review (requires param dealerId)
-    # POST: save-review
-DEALERSHIP_API_URL = "https://1984d932.us-south.apigw.appdomain.cloud/api/dealerships" 
-    # GET: get-all-dealers
-STATE_DEALERS_API_URL = "https://1984d932.us-south.apigw.appdomain.cloud/api/state-dealers"
-    # GET: get-state-dealers (requires param state)
 
 
 # #
@@ -106,6 +97,16 @@ def registration_request(request):
 # IBM CLOUD FUNCTION API INTERACTIONS
 # #
 
+# API URLS - all GET requests return JSON with "entries" key containing list of reviews
+REVIEW_API_URL = "https://1984d932.us-south.apigw.appdomain.cloud/api/review " 
+    # GET: get-dealer-review (requires param dealerId)
+    # POST: save-review
+DEALERSHIP_API_URL = "https://1984d932.us-south.apigw.appdomain.cloud/api/dealerships" 
+    # GET: get-all-dealers
+STATE_DEALERS_API_URL = "https://1984d932.us-south.apigw.appdomain.cloud/api/state-dealers"
+    # GET: get-state-dealers (requires param state)
+
+
 def get_dealerships(request):
     context = {}
     if request.method == "GET":
@@ -117,6 +118,17 @@ def get_dealerships(request):
         context['dealers'] = dealer_names
         return render(request, 'djangoapp/index.html', context)
 
+
+def get_state_dealers(request, state):
+    context = {}
+    if request.method == "GET":
+        # Run get-state-dealers Function
+        url = STATE_DEALERS_API_URL
+        dealerships = get_dealer_by_state_from_cf(url, state=state)
+        dealer_names = ' '.join([dealer.short_name for dealer in dealerships])
+
+        context['dealers'] = dealer_names
+        return render(request, 'djangoapp/index.html', context)
 
 # Create a `get_dealer_details` view to render the reviews of a dealer
 def get_dealer_details(request, dealer_id):

--- a/server/djangoapp/views.py
+++ b/server/djangoapp/views.py
@@ -103,12 +103,8 @@ def get_dealerships(request):
         # My API is currently setup to allow the following link to run the "get-all-dealers" Function
         url = "https://1984d932.us-south.apigw.appdomain.cloud/api/dealership"
         dealerships = get_dealers_from_cf(url) # should be a list of CarDealer objs.
-        #dealer_names = ' '.join([dealer.short_name for dealer in dealerships]) # dot-access cuz it should be an object...
-        dealer_names = []
-        for dealer in dealerships:
-            print(dealer.short_name)
-            dealer_names.append(dealer.short_name)
-        #dealer_names = set(pull_dealer_names)
+        dealer_names = ' '.join([dealer.short_name for dealer in dealerships]) # dot-access cuz it should be an object...
+        
         context['dealers'] = dealer_names
         return render(request, 'djangoapp/index.html', context)
 


### PR DESCRIPTION
This update brings a few additions:
- Implemented ability to call a Cloud Function to grab Dealer and Review data from Cloudant db (and then store that data in proxy objects)
  - Revised those setups to create data proxy objects more succinctly: also proved to be a great work-around for all those KeyErrors Django would throw while implementing some sorta fallback for missing data.
  - Since we're kinda deviating from the instructions: we have a new API URL and front-end URL for finding dealers by state.
  - updated dealer_details template to extend the base.
  - definitely leaving some of the testing code in the source, as it's pretty useful for general reference.
- Made small updates to the Cloud Functions themselves:
  - included short_name in the format-docs function (it originally just ignored it...)
  - updated pass-the-docs to ensure the numerical dealerID from the URL param was converted back to a number

I didn't commit a lot of the saved versions of the updated files that I was working on, but I did leave quite a few notes on the issues themselves. We can close #14, close #15, and fix #43 now 👍 Any suggested changes can open a new issue, since the data is now displaying the app without issue.